### PR TITLE
Implement drop and list

### DIFF
--- a/commands/dropme.js
+++ b/commands/dropme.js
@@ -32,6 +32,6 @@ module.exports = {
         if (!rolePermissions.has(PermissionsBitField.Flags.ViewChannel)) {
             return message.reply('You need to specify a spoiler channel.');
         }
-        await channel.permissionOverwrites.delete(message.member)
+        await channel.permissionOverwrites.delete(message.member);
     }
 }

--- a/commands/dropme.js
+++ b/commands/dropme.js
@@ -1,0 +1,37 @@
+module.exports = {
+	name: 'dropme',
+	description: 'Removes command user from a private channel.',
+    args: true,
+    usage: '<channel name>',
+    guildOnly: true,
+    cooldown: 0,
+    async execute(client, message, args) {
+        const { PermissionsBitField } = require('discord.js');
+
+        //checks if channel name in args is valid
+        if (!message.guild.channels.cache.find(channel => channel.name === args[0])) {
+            return message.reply('You need to include a valid channel name.');
+        }
+
+        const channel = message.guild.channels.cache.find(channel => channel.name === args[0]);
+        const role = message.guild.roles.cache.find(role => role.name === "Spoilers");
+
+        //checks if there is a "Spoilers" role in the server
+        if (!role) {
+            return message.reply('There is no "Spoilers" role in this server.');
+        }
+
+        const rolePermissions = channel.permissionsFor(role);
+
+        //checks if the Spoilers role permissions are null
+        if (!rolePermissions) {
+            return message.reply('Error finding spoiler role permissions.');
+        }
+
+        //checks if the Spoilers role has permissions in the channel from args
+        if (!rolePermissions.has(PermissionsBitField.Flags.ViewChannel)) {
+            return message.reply('You need to specify a spoiler channel.');
+        }
+        await channel.permissionOverwrites.delete(message.member)
+    }
+}

--- a/commands/list.js
+++ b/commands/list.js
@@ -5,28 +5,57 @@ module.exports = {
     guildOnly: true,
     cooldown: 0,
     async execute(client, message, args) {
-        const { PermissionsBitField } = require('discord.js');
+        const { PermissionsBitField, ChannelType } = require('discord.js');
+        //channel cache is a collection type
         const channels = message.guild.channels.cache;
         const role = message.guild.roles.cache.find(role => role.name === "Spoilers");
-
         //checks if there is a "Spoilers" role in the server
         if (!role) {
             return message.reply('There is no "Spoilers" role in this server.');
         }
+        const categories = channels.filter(channel => channel.type === ChannelType.GuildCategory);
+        let mapOfSpoilerCategories = new Map();
 
-        const spoilersChannels = channels.filter(channel => {
-            const rolePermissions = channel.permissionsFor(role);
-            if (!rolePermissions) {
-                return false;
-            }
-            if (!rolePermissions.has(PermissionsBitField.Flags.ViewChannel)) {
-                return false;
-            }
-            return true;
-        });
-        //TODO: Stuff into an embed
+        for (const category of categories){
+            let spoilersInCategory = category.children.cache.filter(
+                channel => {
+                    const rolePermissions = channel.permissionsFor(role);
+                    if (!rolePermissions) {
+                        return false;
+                    }
+                    if (!rolePermissions.has(PermissionsBitField.Flags.ViewChannel)) {
+                        return false;
+                    }
+                    return true;
+            });
+            //for each category, add sorted spoiler channels of that category to the list to print
+            if (spoilersInCategory.size > 0) mapOfSpoilerCategories.set(
+                category.name, 
+                spoilersInCategory.cache.sort(a,b => {return a.localeCompare(b)})
+                )
+        };
+
+        // const spoilersChannels = channels.filter(channel => {
+        //     const rolePermissions = channel.permissionsFor(role);
+        //     if (!rolePermissions) {
+        //         return false;
+        //     }
+        //     if (!rolePermissions.has(PermissionsBitField.Flags.ViewChannel)) {
+        //         return false;
+        //     }
+        //     return true;
+        // });
+        //TODO: Stuff into an embed, probably find a cleaner method of stitching this together
+        // Character limits??
+
+        
         let messageBody = 'List of channels:'; 
-        spoilersChannels.each(channel => messageBody += `\n${channel}`)
+        mapOfSpoilerCategories.forEach((value, key)=>{
+            messageBody += `\n**${key}**\n`;
+            messageBody += value.values().join('\n');
+            messageBody += `\n`;
+        })
+        spoilersChannels.each(channel => messageBody += `\n${channel}`);
         return message.reply(messageBody);
     }
 }

--- a/commands/list.js
+++ b/commands/list.js
@@ -1,0 +1,32 @@
+module.exports = {
+	name: 'dropme',
+	description: 'Removes command user from a private channel.',
+    args: false,
+    guildOnly: true,
+    cooldown: 0,
+    async execute(client, message, args) {
+        const { PermissionsBitField } = require('discord.js');
+        const channels = message.guild.channels.cache;
+        const role = message.guild.roles.cache.find(role => role.name === "Spoilers");
+
+        //checks if there is a "Spoilers" role in the server
+        if (!role) {
+            return message.reply('There is no "Spoilers" role in this server.');
+        }
+
+        const spoilersChannels = channels.filter(channel => {
+            const rolePermissions = channel.permissionsFor(role);
+            if (!rolePermissions) {
+                return false;
+            }
+            if (!rolePermissions.has(PermissionsBitField.Flags.ViewChannel)) {
+                return false;
+            }
+            return true;
+        });
+        //TODO: Stuff into an embed
+        let messageBody = 'List of channels:'; 
+        spoilersChannels.each(channel => messageBody += `\n${channel}`)
+        return message.reply(messageBody);
+    }
+}


### PR DESCRIPTION
Implements two features for the bot, one that removes users from channels and one that lists channels that have the spoiler role.

This is quick, dirty, and untested, but may help provide a starting point.